### PR TITLE
Update Dockerfile to support Python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for yunojuno/heroku
 #
 # Read setup.sh for a better rundown.
-# 
+#
 # Images get tagged with the Python major version:
 #
 #    e.g yunojuno/heroku:3.9-latest

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ because it means we lean on them for security updates to the underlying stack.
 | Dockerfile             | Base               | repo/image:tag               |
 |------------------------|--------------------|------------------------------|
 | `Dockerfile`           | `heroku/heroku:20` | `yunojuno/heroku:3.9-latest` |
+| `Dockerfile`           | `heroku/heroku:20` | `yunojuno/heroku:3.10-latest` |
 
 ## CI
 

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,7 @@ ln -s /usr/bin/python3.10 /usr/bin/python3
 # build in prod, but this is extremely rare and we can override the
 # buildpack fairly easily to sort any issues.
 python -m ensurepip --upgrade
-pip3 install --upgrade setuptools pip
+pip3 install --upgrade setuptools pip wheel
 
 # do not install poetry using pip - its dependencies cause conflicts with
 # ours. Installing this way defaults to installing the binary in the local

--- a/setup.sh
+++ b/setup.sh
@@ -40,15 +40,16 @@ apt-get update
 #   2) Update throughout this script
 #   3) Update FROM tags downstream (e.g yunojuno/platform)
 apt-get install -y --no-install-recommends \
-    python3.9 \
-    python3.9-dev \
-    python3-pip
+    python3.10 \
+    python3.10-dev \
+    python3.10-distutils \
+    python3.10-venv  # includes ensurepip
 
 # Relink default binaries to new Python install
 rm /usr/bin/python
 rm /usr/bin/python3
-ln -s /usr/bin/python3.9 /usr/bin/python
-ln -s /usr/bin/python3.9 /usr/bin/python3
+ln -s /usr/bin/python3.10 /usr/bin/python
+ln -s /usr/bin/python3.10 /usr/bin/python3
 
 # Upgrade Python-related packages to their latest versions. This
 # actually doesn't match what the buildpacks in production do, as
@@ -58,6 +59,7 @@ ln -s /usr/bin/python3.9 /usr/bin/python3
 # before Heroku upgrade. This is at the expense of the odd failed
 # build in prod, but this is extremely rare and we can override the
 # buildpack fairly easily to sort any issues.
+python -m ensurepip --upgrade
 pip3 install --upgrade setuptools pip poetry
 
 # Remove other pip binaries to reduce confusion over
@@ -85,9 +87,9 @@ echo "  - $(python --version)"
 echo "python3:"
 echo "  - $(which python3)"
 echo "  - $(python3 --version)"
-echo "python3.9:"
-echo "  - $(which python3.9)"
-echo "  - $(python3.9 --version)"
+echo "python3.10:"
+echo "  - $(which python3.10)"
+echo "  - $(python3.10 --version)"
 echo "pip:"
 echo "  $(which pip)"
 echo "  $(pip --version)"

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,13 @@ ln -s /usr/bin/python3.10 /usr/bin/python3
 # build in prod, but this is extremely rare and we can override the
 # buildpack fairly easily to sort any issues.
 python -m ensurepip --upgrade
-pip3 install --upgrade setuptools pip poetry
+pip3 install --upgrade setuptools pip
+
+# do not install poetry using pip - its dependencies cause conflicts with
+# ours. Installing this way defaults to installing the binary in the local
+# user's ~/.local/ folder - which isn't on the PATH.
+curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python -
+cp /etc/poetry/bin/poetry /usr/bin/poetry
 
 # Remove other pip binaries to reduce confusion over
 # which one should actually be used.


### PR DESCRIPTION
Fixes #11 

Challenge here was getting pip installed correctly. Counterintuitively 
the answer was installing `python3.10-venv`, which includes `ensurepip`
which can be used to install the latest pip.
