### PR TITLE
Misc: Upgrade Heroku Stack from 20 to 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@
 #
 # Images get tagged with the Python major version:
 #
-#    e.g yunojuno/heroku:3.9-latest
+#    e.g yunojuno/heroku:3.10-latest
 
-FROM heroku/heroku:20
+FROM heroku/heroku:22
 
 LABEL maintainer "YunoJuno <code@yunojuno.com>"
 


### PR DESCRIPTION
Switch to Heroku base image from their 22 stack, which utilises the 22.04 Ubuntu base image.

Build output:

```
Python-ecosystem
================

python:
  - /usr/bin/python
  - Python 3.10.4
python3:
  - /usr/bin/python3
  - Python 3.10.4
python3.10:
  - /usr/bin/python3.10
  - Python 3.10.4
pip:
  /usr/local/bin/pip
  pip 22.2 from /usr/local/lib/python3.10/dist-packages/pip (python 3.10)
poetry:
  - /usr/bin/poetry
  - Poetry version 1.1.14
```

Note the new comments, two key things:

* while on 3.10 - we're getting the packages direct from Ubuntu, not deadsnakes.
* because of this, deadsnakes is not providing its custom python3.10-venv which keeps the `ensurepip` module, and thus we must install pip via the `get-pip.py` method.