### PR TITLE
Build for arm64 architecture

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -56,3 +56,5 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           no-cache: true
+          # Build for both architectures (devs have M1)
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,7 +39,7 @@ jobs:
             type=raw,value=3.10-latest
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}


### PR DESCRIPTION
Ensures this image is built to cater for devices which run `arm64` architecture so the image can be successfully pulled and built for M1 machines.