### PR TITLE
Schedule docker rebuilds every six hours

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,8 +3,9 @@ name: Docker Build
 on:
   schedule:
     # Schedule runs run off HEAD commit on master.
-    # Run every 6 hours (4x/day) to keep yunojuno/heroku up to
-    # date with Heroku's base image. We run multiple times a day so that a single flaky failure does not hurt downstream delivery.
+    # Run every 6 hours (4x/day) to keep yunojuno/heroku up to date
+    # with Heroku's base image. We run multiple times a day so that a
+    # single flaky failure does not hurt downstream delivery.
     - cron:  '0 */6 * * *'
 
   push:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # Schedule runs run off HEAD commit on master.
     # Run every 6 hours (4x/day) to keep yunojuno/heroku up to
-    # date with Heroku's base image.
+    # date with Heroku's base image. We run multiple times a day so that a single flaky failure does not hurt downstream delivery.
     - cron:  '0 */6 * * *'
 
   push:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,9 +3,9 @@ name: Docker Build
 on:
   schedule:
     # Schedule runs run off HEAD commit on master.
-    # Run once a day to keep yunojuno/heroku up to
+    # Run every 6 hours (4x/day) to keep yunojuno/heroku up to
     # date with Heroku's base image.
-    - cron:  '0 23 * * *'
+    - cron:  '0 */6 * * *'
 
   push:
     branches:


### PR DESCRIPTION
Update Docker rebuild workflow to run every 6 hours instead of daily.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a35bcb6-1538-4019-b619-7c3f83d95aa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7a35bcb6-1538-4019-b619-7c3f83d95aa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

