### PR TITLE
Misc: Build and publish arm variant of heroku image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -70,7 +70,7 @@ jobs:
           pull: true
           push: true
           no-cache: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
We pretty much all work on arm based macos laptops, and soon we're going to learn on running these containers in production. Adding support for arm images to this repo will let us do the same for our application images.

The underlying heroku image already publishes an arm variant, and I've tested the build locally so this should be fine.